### PR TITLE
 Fixing error data type calculating in plot_y

### DIFF
--- a/chapter3_NN/logistic-regression/logistic-regression.ipynb
+++ b/chapter3_NN/logistic-regression/logistic-regression.ipynb
@@ -383,9 +383,9 @@
    ],
    "source": [
     "# 画出参数更新之前的结果\n",
-    "w0 = w[0].data[0]\n",
-    "w1 = w[1].data[0]\n",
-    "b0 = b.data[0]\n",
+    "w0 = w[0].data[0].numpy()\n",
+    "w1 = w[1].data[0].numpy()\n",
+    "b0 = b.data[0].numpy()\n",
     "\n",
     "plot_x = np.arange(0.2, 1, 0.01)\n",
     "plot_y = (-w0 * plot_x - b0) / w1\n",


### PR DESCRIPTION
@L1aoXingyu 
Many thanks to your great revising version for learning in PyTorch.
However, in the logistic regression section, here should be fixed for error multiplying in **plot_y**
**w0 * plot_x**
 --> This should be calculated only for two same data type, i.e., two nparray or two tensor.